### PR TITLE
Change from RecommendedWatcher to PollWatcher

### DIFF
--- a/crates/memofs/src/std_backend.rs
+++ b/crates/memofs/src/std_backend.rs
@@ -5,23 +5,23 @@ use std::thread;
 use std::time::Duration;
 
 use crossbeam_channel::Receiver;
-use notify::{watcher, DebouncedEvent, RecommendedWatcher, RecursiveMode, Watcher};
+use notify::{DebouncedEvent, PollWatcher, RecursiveMode, Watcher};
 
 use crate::{DirEntry, Metadata, ReadDir, VfsBackend, VfsEvent};
 
 /// `VfsBackend` that uses `std::fs` and the `notify` crate.
 pub struct StdBackend {
-    watcher: RecommendedWatcher,
+    watcher: PollWatcher,
     watcher_receiver: Receiver<VfsEvent>,
 }
 
 impl StdBackend {
     pub fn new() -> StdBackend {
         let (notify_tx, notify_rx) = mpsc::channel();
-        let watcher = watcher(notify_tx, Duration::from_millis(50)).unwrap();
+        let watcher = PollWatcher::new(notify_tx, Duration::from_millis(50)).unwrap();
 
         let (tx, rx) = crossbeam_channel::unbounded();
-
+        
         thread::spawn(move || {
             for event in notify_rx {
                 match event {


### PR DESCRIPTION
Previously Apple M1 serve was incredibly slow and failing to sync changes in large projects. Traced back to this issue in notify library used by memofs: https://github.com/notify-rs/notify/issues/412.

On my Mac M1 changes are syncing and serve startup time went from 1m 15s -> 1s. Not tested on Windows build.