### PR TITLE
Ensures CurrentCamera ref is destroyed in new tree before referents are linked to new DOM

### DIFF
--- a/src/syncback/mod.rs
+++ b/src/syncback/mod.rs
@@ -78,20 +78,9 @@ pub fn syncback_loop(
     log::debug!("Hashing file DOM");
     let new_hashes = hash_tree(project, &new_tree, new_tree.root_ref());
 
-    let ignore_referents = project
-        .syncback_rules
-        .as_ref()
-        .and_then(|s| s.ignore_referents)
-        .unwrap_or_default();
-    if !ignore_referents {
-        log::debug!("Linking referents for new DOM");
-        deferred_referents.link(&mut new_tree)?;
-    } else {
-        log::debug!("Skipping referent linking as per project syncback rules");
-    }
-
     if let Some(syncback_rules) = &project.syncback_rules {
         if !syncback_rules.sync_current_camera.unwrap_or_default() {
+            log::debug!("Removing CurrentCamera from new DOM");
             let mut camera_ref = None;
             for child_ref in new_tree.root().children() {
                 let inst = new_tree.get_by_ref(*child_ref).unwrap();
@@ -105,6 +94,18 @@ pub fn syncback_loop(
                 }
             }
         }
+    }
+
+    let ignore_referents = project
+        .syncback_rules
+        .as_ref()
+        .and_then(|s| s.ignore_referents)
+        .unwrap_or_default();
+    if !ignore_referents {
+        log::debug!("Linking referents for new DOM");
+        deferred_referents.link(&mut new_tree)?;
+    } else {
+        log::debug!("Skipping referent linking as per project syncback rules");
     }
 
     let project_path = project.folder_location();


### PR DESCRIPTION
Previously, the CurrentCamera ref was only being destroyed in the new tree after the referents had been linked to the new DOM - meaning that the `sync_current_camera` property, when set to false, was not being respected as intended. In effect, this meant that, at least in my default.project.json, the `Rojo_Target_CurrentCamera` hash was continuously changing value on every syncback.

Moving the code to happen before the referents are linked now seems to correctly remove the CurrentCamera ref from the new tree, and preserve the same ref attribute value across all syncbacks.