### PR TITLE
Swap JSON map fields to use IndexMap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -735,7 +735,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http",
- "indexmap 2.2.5",
+ "indexmap 2.10.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -756,9 +756,9 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
-version = "0.14.3"
+version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
+checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
 
 [[package]]
 name = "heck"
@@ -887,12 +887,13 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.2.5"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b0b929d511467233429c45a44ac1dcaa21ba0f5ba11e4879e6ed28ddb4f9df4"
+checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.3",
+ "hashbrown 0.15.4",
+ "serde",
 ]
 
 [[package]]
@@ -1859,6 +1860,7 @@ dependencies = [
  "globset",
  "humantime",
  "hyper",
+ "indexmap 2.10.0",
  "insta",
  "jod-thread",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,6 +96,7 @@ profiling = "1.0.15"
 
 blake3 = "1.5.0"
 float-cmp = "0.9.0"
+indexmap = { version = "2.10.0", features = ["serde"] }
 
 [target.'cfg(windows)'.dependencies]
 winreg = "0.10.1"

--- a/src/snapshot_middleware/csv.rs
+++ b/src/snapshot_middleware/csv.rs
@@ -111,7 +111,9 @@ pub fn syncback_csv<'sync>(
 
     let meta = AdjacentMetadata::from_syncback_snapshot(snapshot, snapshot.path.clone())?;
     if let Some(mut meta) = meta {
-        meta.properties.remove(&ustr("Contents"));
+        // LocalizationTables have relatively few properties that we care
+        // about, so shifting is fine.
+        meta.properties.shift_remove(&ustr("Contents"));
 
         if !meta.is_empty() {
             let parent = snapshot.path.parent_err()?;
@@ -149,7 +151,9 @@ pub fn syncback_csv_init<'sync>(
 
     let meta = DirectoryMetadata::from_syncback_snapshot(snapshot, snapshot.path.clone())?;
     if let Some(mut meta) = meta {
-        meta.properties.remove(&ustr("Contents"));
+        // LocalizationTables have relatively few properties that we care
+        // about, so shifting is fine.
+        meta.properties.shift_remove(&ustr("Contents"));
         if !meta.is_empty() {
             dir_syncback.fs_snapshot.add_file(
                 snapshot.path.join("init.meta.json"),

--- a/src/snapshot_middleware/json_model.rs
+++ b/src/snapshot_middleware/json_model.rs
@@ -1,6 +1,7 @@
-use std::{borrow::Cow, collections::BTreeMap, path::Path, str};
+use std::{borrow::Cow, path::Path, str};
 
 use anyhow::Context;
+use indexmap::IndexMap;
 use memofs::Vfs;
 use rbx_dom_weak::{
     types::{Attributes, Ref, Variant},
@@ -92,8 +93,8 @@ fn json_model_from_pair<'sync>(
 
     filter_properties_preallocated(snapshot.project(), new_inst, prop_buffer);
 
-    let mut properties = BTreeMap::new();
-    let mut attributes = BTreeMap::new();
+    let mut properties = IndexMap::new();
+    let mut attributes = IndexMap::new();
     for (name, value) in prop_buffer.drain(..) {
         match value {
             Variant::Attributes(attrs) => {
@@ -165,12 +166,12 @@ struct JsonModel {
     #[serde(
         alias = "Properties",
         default,
-        skip_serializing_if = "BTreeMap::is_empty"
+        skip_serializing_if = "IndexMap::is_empty"
     )]
-    properties: BTreeMap<Ustr, UnresolvedValue>,
+    properties: IndexMap<Ustr, UnresolvedValue>,
 
-    #[serde(default = "BTreeMap::new", skip_serializing_if = "BTreeMap::is_empty")]
-    attributes: BTreeMap<String, UnresolvedValue>,
+    #[serde(default = "IndexMap::new", skip_serializing_if = "IndexMap::is_empty")]
+    attributes: IndexMap<String, UnresolvedValue>,
 }
 
 impl JsonModel {

--- a/src/snapshot_middleware/lua.rs
+++ b/src/snapshot_middleware/lua.rs
@@ -160,7 +160,9 @@ pub fn syncback_lua<'sync>(
 
     let meta = AdjacentMetadata::from_syncback_snapshot(snapshot, snapshot.path.clone())?;
     if let Some(mut meta) = meta {
-        meta.properties.remove(&ustr("Source"));
+        // Scripts have relatively few properties that we care about, so shifting
+        // is fine.
+        meta.properties.shift_remove(&ustr("Source"));
 
         if !meta.is_empty() {
             let parent_location = snapshot.path.parent_err()?;
@@ -202,7 +204,9 @@ pub fn syncback_lua_init<'sync>(
 
     let meta = DirectoryMetadata::from_syncback_snapshot(snapshot, path.clone())?;
     if let Some(mut meta) = meta {
-        meta.properties.remove(&ustr("Source"));
+        // Scripts have relatively few properties that we care about, so shifting
+        // is fine.
+        meta.properties.shift_remove(&ustr("Source"));
 
         if !meta.is_empty() {
             dir_syncback.fs_snapshot.add_file(

--- a/src/snapshot_middleware/meta_file.rs
+++ b/src/snapshot_middleware/meta_file.rs
@@ -1,9 +1,7 @@
-use std::{
-    collections::BTreeMap,
-    path::{Path, PathBuf},
-};
+use std::path::{Path, PathBuf};
 
 use anyhow::{format_err, Context};
+use indexmap::IndexMap;
 use memofs::{IoResultExt as _, Vfs};
 use rbx_dom_weak::{
     types::{Attributes, Variant},
@@ -31,11 +29,11 @@ pub struct AdjacentMetadata {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ignore_unknown_instances: Option<bool>,
 
-    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
-    pub properties: BTreeMap<Ustr, UnresolvedValue>,
+    #[serde(default, skip_serializing_if = "IndexMap::is_empty")]
+    pub properties: IndexMap<Ustr, UnresolvedValue>,
 
-    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
-    pub attributes: BTreeMap<String, UnresolvedValue>,
+    #[serde(default, skip_serializing_if = "IndexMap::is_empty")]
+    pub attributes: IndexMap<String, UnresolvedValue>,
 
     #[serde(skip)]
     pub path: PathBuf,
@@ -60,8 +58,8 @@ impl AdjacentMetadata {
         snapshot: &SyncbackSnapshot,
         path: PathBuf,
     ) -> anyhow::Result<Option<Self>> {
-        let mut properties = BTreeMap::new();
-        let mut attributes = BTreeMap::new();
+        let mut properties = IndexMap::new();
+        let mut attributes = IndexMap::new();
         // TODO make this more granular.
         // I am breaking the cycle of bad TODOs. This is in reference to the fact
         // that right now, this will just not write any metadata at all for
@@ -215,11 +213,11 @@ pub struct DirectoryMetadata {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ignore_unknown_instances: Option<bool>,
 
-    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
-    pub properties: BTreeMap<Ustr, UnresolvedValue>,
+    #[serde(default, skip_serializing_if = "IndexMap::is_empty")]
+    pub properties: IndexMap<Ustr, UnresolvedValue>,
 
-    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
-    pub attributes: BTreeMap<String, UnresolvedValue>,
+    #[serde(default, skip_serializing_if = "IndexMap::is_empty")]
+    pub attributes: IndexMap<String, UnresolvedValue>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub class_name: Option<Ustr>,
@@ -250,8 +248,8 @@ impl DirectoryMetadata {
         snapshot: &SyncbackSnapshot,
         path: PathBuf,
     ) -> anyhow::Result<Option<Self>> {
-        let mut properties = BTreeMap::new();
-        let mut attributes = BTreeMap::new();
+        let mut properties = IndexMap::new();
+        let mut attributes = IndexMap::new();
         // TODO make this more granular.
         // I am breaking the cycle of bad TODOs. This is in reference to the fact
         // that right now, this will just not write any metadata at all for

--- a/src/snapshot_middleware/txt.rs
+++ b/src/snapshot_middleware/txt.rs
@@ -57,7 +57,9 @@ pub fn syncback_txt<'sync>(
 
     let meta = AdjacentMetadata::from_syncback_snapshot(snapshot, snapshot.path.clone())?;
     if let Some(mut meta) = meta {
-        meta.properties.remove(&ustr("Value"));
+        // StringValues have relatively few properties that we care about, so
+        // shifting is fine.
+        meta.properties.shift_remove(&ustr("Value"));
 
         if !meta.is_empty() {
             let parent = snapshot.path.parent_err()?;

--- a/src/syncback/mod.rs
+++ b/src/syncback/mod.rs
@@ -6,10 +6,11 @@ mod ref_properties;
 mod snapshot;
 
 use anyhow::Context;
+use indexmap::IndexMap;
 use memofs::Vfs;
 use rbx_dom_weak::{
     types::{Ref, Variant},
-    ustr, Instance, Ustr, UstrMap, UstrSet, WeakDom,
+    ustr, Instance, Ustr, UstrSet, WeakDom,
 };
 use serde::{Deserialize, Serialize};
 use std::{
@@ -382,8 +383,8 @@ pub struct SyncbackRules {
     ignore_paths: Vec<String>,
     /// A map of classes to properties to ignore for that class when doing
     /// syncback.
-    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
-    ignore_properties: UstrMap<Vec<Ustr>>,
+    #[serde(default, skip_serializing_if = "IndexMap::is_empty")]
+    ignore_properties: IndexMap<Ustr, Vec<Ustr>>,
     /// Whether or not the `CurrentCamera` of `Workspace` is included in the
     /// syncback or not. Defaults to `false`.
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/syncback/snapshot.rs
+++ b/src/syncback/snapshot.rs
@@ -1,3 +1,4 @@
+use indexmap::IndexMap;
 use memofs::Vfs;
 use std::path::{Path, PathBuf};
 
@@ -188,7 +189,7 @@ impl<'sync> SyncbackSnapshot<'sync> {
 
     /// Returns user-specified property ignore rules.
     #[inline]
-    pub fn ignore_props(&self) -> Option<&UstrMap<Vec<Ustr>>> {
+    pub fn ignore_props(&self) -> Option<&IndexMap<Ustr, Vec<Ustr>>> {
         self.data
             .project
             .syncback_rules


### PR DESCRIPTION
Right now we use `BTreeMap` for everything, which works to guarantee a stable order but it does not preserve user intention. After some internal feedback, this has proven to be annoying and we should fix it.

Swapping from `BTreeMap` to `IndexMap` should have minimal performance cost (the most significant one is probably with syncbacking metadata), and it'll preserve people's intended insertion orders.